### PR TITLE
Bugfix discussion editor heading

### DIFF
--- a/front-end/src/components/DiscussionEntries/DiscussionEntryEditor.jsx
+++ b/front-end/src/components/DiscussionEntries/DiscussionEntryEditor.jsx
@@ -80,16 +80,17 @@ export default function DiscussionEntryEditor({
           placeholder="Short title/summary or your entry... "
         />
       </label>
-      <label>
+      <label htmlFor='text-editor'>
         Details (optional):
-        <TextEditor
-          placeholder={editorPlaceholder}
-          value={details}
-          setValue={setDetails}
-          files={files}
-          setFiles={setFiles}
-        />
       </label>
+      <TextEditor
+        id='text-editor'
+        placeholder={editorPlaceholder}
+        value={details}
+        setValue={setDetails}
+        files={files}
+        setFiles={setFiles}
+        />
 
       <button type="submit">Publish</button>
     </form>

--- a/front-end/src/components/TextEditor/TextEditor.js
+++ b/front-end/src/components/TextEditor/TextEditor.js
@@ -3,7 +3,7 @@ import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
 const toolbarOptions = [
-  [{ header: [1, 2, 3, 4, 5, 6, false] }],
+  [{ header: [1, 2, 3, false] }],
   ['bold', 'italic'], // Basic text styles
   ['link', 'image'], // Links and images
   ['blockquote'],


### PR DESCRIPTION
The header list in Quill editro in teh discussions component wasnt' working
WHen you click it, it blinks and disappears

somehow it was related to the internal or Quill.
I was putting in in a Lable component.
but once I got it out, it worked.

I also edited the number of H levels there